### PR TITLE
remove duplicate resource item

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -38,7 +38,6 @@ let package = Package(
                 .product(name: "Algorithms", package: "swift-algorithms")
             ],
             resources: [
-                .process("Resources"),
                 .process("Resources/amplifyconfiguration.json"),
                 .process("Resources/SenseyeAssets.xcassets")
             ]),


### PR DESCRIPTION
Overlapping resources processing commands are causing a build failure 